### PR TITLE
Update history inserts (fix for recent rubies)

### DIFF
--- a/lib/ori/internals.rb
+++ b/lib/ori/internals.rb
@@ -186,14 +186,18 @@ module ORI
       ])
     end
 
-    # Stuff a ready-made "<subject>.ri " command into Readline history if last request had an argument.
+    # Stuff a ready-made "<subject>.ri " command into history if last request had an argument.
     def self.do_history
+      linelib = Reline rescue Readline rescue nil
+
+      return unless linelib
+
       # `cmd` is actually THIS command being executed.
-      cmd = Readline::HISTORY.to_a.last
+      cmd = linelib::HISTORY.to_a.last
       if prefix = get_ri_arg_prefix(cmd)
-        Readline::HISTORY.pop
-        Readline::HISTORY.push "#{prefix} "
-        Readline::HISTORY.push cmd
+        linelib::HISTORY.pop
+        linelib::HISTORY.push "#{prefix} "
+        linelib::HISTORY.push cmd
       end
     end
 


### PR DESCRIPTION
Hello and thx for this nice gem.

I noticed a problem recently. In ruby 2.7+ `Readline` was replaced with `Reline`, a pure ruby readline implementation with same API. Unfortunately history manipulations are not valid anymore (as instead of `Readline`, `Reline` constant should be referenced from now on).

So maybe ori could do this:

 - use Reline if available
 - fallback to Readline otherwise
 - if both are missing do nothing

Cheers
🍷 